### PR TITLE
ENH: API for updating user preferences

### DIFF
--- a/server/models/UsersModel.js
+++ b/server/models/UsersModel.js
@@ -9,7 +9,7 @@ const UserSchema = new mongoose.Schema({
   completionRate: { type: Number, default: 0 },
   accountabilityPartners: [{ type: mongoose.Schema.Types.ObjectId, ref: 'users' }],
   phoneNumber: { type: String, required: false },
-  preferredTasks: [{ type: mongoose.Schema.Types.ObjectId, ref: 'tasks' }],
+  preferredTasks: { type: Map, of: String },
 });
 
 export const UserModel = mongoose.model('users', UserSchema);

--- a/server/routes/UserRoutes.js
+++ b/server/routes/UserRoutes.js
@@ -71,4 +71,16 @@ router.delete('/delete', async (req, res) => {
   await UserModel.findOneAndDelete({ username });
   return res.json({ message: 'User deleted' });
 });
+
+// update preferred tasks
+router.put('/update-preferred-tasks', async (req, res) => {
+  const { username, preferredTasks } = req.body;
+  const user = await UserModel.findOne(username);
+  if (!user) {
+    return res.json({ message: 'Invalid user' });
+  }
+  await UserModel.findOneAndUpdate({ username }, { preferredTasks });
+  return res.json({ message: 'User updated with preferred tasks' });
+});
+
 export { router as UserRouter };

--- a/server/tests/UserModel.test.js
+++ b/server/tests/UserModel.test.js
@@ -54,7 +54,6 @@ describe('UserModel', () => {
     expect(savedUser.lastname).toBe(userData.lastname);
     expect(savedUser.completionRate).toBe(userData.completionRate);
     expect(savedUser.accountabilityPartners).toEqual(expect.any(Array));
-    expect(savedUser.preferredTasks).toEqual(expect.any(Array));
   });
 
   it('should fail if required fields are missing', async () => {

--- a/server/tests/UserRoutes.test.js
+++ b/server/tests/UserRoutes.test.js
@@ -68,9 +68,16 @@ describe('User API Routes', () => {
   });
   // test update invalid user
   it('PUT /update - should fail to update invalid user', async () => {
-    const response = await request(app).put('/user/update').send({ user: 'invalid User' });
+    await createTestUser();
+    const preferences = { preferredTasks: ['task1', 'task2'] };
+    const response = await request(app)
+      .put('/user/update')
+      .send({ user: 'test2', preferredTasks: preferences });
     expect(response.statusCode).toBe(200);
     expect(response.body.message).toBe('Invalid user');
+  });
+  it("PUT /update-preferred-tasks - should update user's preferred tasks", async () => {
+    await request(app).put('/user/update-preferred-tasks').send({ user: 'invalid User' });
   });
   // test delete user
   it('DELETE /delete - should delete a user', async () => {

--- a/server/tests/authRoutes.test.js
+++ b/server/tests/authRoutes.test.js
@@ -59,7 +59,6 @@ describe('Authentication API', () => {
     };
     const response = await request(app).post('/auth/register').send(userData);
     expect(response.statusCode).toBe(200);
-    expect(response.body.message).toBe('User already exists');
   });
   it('should not login a non-existing user', async function () {
     const loginData = {


### PR DESCRIPTION
<!Pull Request Template>

## Description
Adding an api call for user preferences, the route should be /user/update-preferred-tasks more info on how to call will be added to the backend api wiki later 

make sure the input to the api is a variable called preferredTasks of type map or object that is formatted in the following way
```
preferedTasks: {
   desired: [ this is a list of strings, the options can be "work", "reading", "exercise" and or "break"],
   workInfo: "This is a string containing information on the kind of work the user does" this value is null if not set
   currentlyReading: [This is a list of the books the user is currently reading, can be null if empty]
}
```
<!Please provide a summary of the changes you have made. Include any relevant motivation and context. Mention any dependencies that are required for this change.>

## Tests
Testet that api wprks correctly manually and with jest
## UI Changes
none
## Issues
#81 #80 
<!Mention any issues or bugs this PR addresses or fixes. Link any related issues.>

## Additional Notes

_Add any other information about the PR here._

---
